### PR TITLE
prevent overlaps

### DIFF
--- a/app/Schengen/AddSchengenDate.tsx
+++ b/app/Schengen/AddSchengenDate.tsx
@@ -1,9 +1,10 @@
-import { Accessor, Component, Show } from "solid-js";
+import { Accessor, Component, For, Show } from "solid-js";
 import { Popover } from "@ark-ui/solid";
 import { Input } from "common/Input";
 import { Button } from "common/Button";
 import {
   createForm,
+  getValue,
   reset,
   SubmitHandler,
   zodForm,
@@ -13,6 +14,7 @@ import { SchengenDate } from "./types";
 import { isAfter, isMatch, isSameDay } from "date-fns";
 import { Icon } from "common/Icon";
 import { toast } from "common/toast";
+import { formattedDate } from "common/formattedDate";
 
 const schema = z.object({
   date: z
@@ -34,6 +36,10 @@ type DateForm = z.infer<typeof schema>;
 
 type Props = {
   dates: Accessor<SchengenDate[]>;
+  overlappingTrips: (
+    date: Date | string,
+    endDate?: Date | string,
+  ) => SchengenDate[];
   setDates: (dates: SchengenDate[]) => void;
 };
 
@@ -123,6 +129,26 @@ export const AddSchengenDate: Component<Props> = (props) => {
                   </div>
                 )}
               </Field>
+              <For
+                each={props.overlappingTrips(
+                  getValue(dateForm, "date") ?? "",
+                  getValue(dateForm, "endDate") ?? undefined,
+                )}
+              >
+                {(trip) => {
+                  const tripDates = `${formattedDate(trip.date)} - ${formattedDate(trip.endDate)}`;
+                  return (
+                    <p class="text-red-500">
+                      <span>overlaps with </span>
+                      <span>
+                        <Show when={trip.name} fallback={tripDates}>
+                          {trip.name} ({tripDates})
+                        </Show>
+                      </span>
+                    </p>
+                  );
+                }}
+              </For>
               <Button type="submit">Add</Button>
             </Popover.Description>
           </Form>

--- a/app/Schengen/AddSchengenDate.tsx
+++ b/app/Schengen/AddSchengenDate.tsx
@@ -15,6 +15,7 @@ import { isAfter, isMatch, isSameDay } from "date-fns";
 import { Icon } from "common/Icon";
 import { toast } from "common/toast";
 import { formattedDate } from "common/formattedDate";
+import { useTrips } from "app/Schengen/useTrips";
 
 const schema = z.object({
   date: z
@@ -36,14 +37,12 @@ type DateForm = z.infer<typeof schema>;
 
 type Props = {
   dates: Accessor<SchengenDate[]>;
-  overlappingTrips: (
-    date: Date | string,
-    endDate?: Date | string,
-  ) => SchengenDate[];
   setDates: (dates: SchengenDate[]) => void;
 };
 
 export const AddSchengenDate: Component<Props> = (props) => {
+  const { overlappingTrips } = useTrips(props.dates);
+
   const [dateForm, { Form, Field }] = createForm<DateForm>({
     validate: zodForm(schema),
   });
@@ -130,7 +129,7 @@ export const AddSchengenDate: Component<Props> = (props) => {
                 )}
               </Field>
               <For
-                each={props.overlappingTrips(
+                each={overlappingTrips(
                   getValue(dateForm, "date") ?? "",
                   getValue(dateForm, "endDate") ?? undefined,
                 )}

--- a/app/Schengen/Schengen.tsx
+++ b/app/Schengen/Schengen.tsx
@@ -5,7 +5,13 @@ import { useQueryDates } from "app/DaysTracker/useQueryDates";
 import { DayActions } from "app/DaysTracker/Day/DayActions";
 import { Menu } from "app/DaysTracker/Menu";
 import { SchengenTrip } from "app/Schengen/SchengenTrip";
-import { isAfter, isPast } from "date-fns";
+import {
+  areIntervalsOverlapping,
+  isAfter,
+  isPast,
+  isValid,
+  isWithinInterval,
+} from "date-fns";
 import { Summary } from "app/Schengen/Summary";
 import { SchengenDate } from "app/Schengen/types";
 import { AddSchengenDate } from "app/Schengen/AddSchengenDate";
@@ -48,6 +54,42 @@ export const Schengen = () => {
   };
   const resetDates = () => setDates([]);
 
+  const overlappingTrips = (date: Date | string, endDate?: Date | string) => {
+    if (!date && !endDate) return [];
+
+    if (endDate) {
+      if (!isValid(new Date(endDate)) || !isValid(new Date(date))) {
+        console.error(
+          `received invalid dates ("${date}", "${endDate}") when trying to find overlapping trips.`,
+        );
+        return [];
+      }
+      return dates().filter((trip) =>
+        areIntervalsOverlapping(
+          { start: date, end: endDate },
+          {
+            start: trip.date,
+            end: trip.endDate,
+          },
+        ),
+      );
+    }
+
+    if (!isValid(new Date(date))) {
+      console.error(
+        `received invalid date "${date}" when trying to find overlapping trips.`,
+      );
+      return [];
+    }
+
+    return dates().filter((trip) =>
+      isWithinInterval(date, {
+        start: trip.date,
+        end: trip.endDate,
+      }),
+    );
+  };
+
   const fallback = <p class="text-gray-500">Add a trip below</p>;
 
   return (
@@ -79,8 +121,12 @@ export const Schengen = () => {
           )}
         </For>
       </ul>
-      <AddSchengenDate dates={dates} setDates={setDates} />
-      <Summary dates={dates} />
+      <AddSchengenDate
+        dates={dates}
+        overlappingTrips={overlappingTrips}
+        setDates={setDates}
+      />
+      <Summary dates={dates} overlappingTrips={overlappingTrips} />
       <Menu dates={dates} resetDates={resetDates} />
     </main>
   );

--- a/app/Schengen/Schengen.tsx
+++ b/app/Schengen/Schengen.tsx
@@ -5,13 +5,7 @@ import { useQueryDates } from "app/DaysTracker/useQueryDates";
 import { DayActions } from "app/DaysTracker/Day/DayActions";
 import { Menu } from "app/DaysTracker/Menu";
 import { SchengenTrip } from "app/Schengen/SchengenTrip";
-import {
-  areIntervalsOverlapping,
-  isAfter,
-  isPast,
-  isValid,
-  isWithinInterval,
-} from "date-fns";
+import { isAfter, isPast } from "date-fns";
 import { Summary } from "app/Schengen/Summary";
 import { SchengenDate } from "app/Schengen/types";
 import { AddSchengenDate } from "app/Schengen/AddSchengenDate";
@@ -54,42 +48,6 @@ export const Schengen = () => {
   };
   const resetDates = () => setDates([]);
 
-  const overlappingTrips = (date: Date | string, endDate?: Date | string) => {
-    if (!date && !endDate) return [];
-
-    if (endDate) {
-      if (!isValid(new Date(endDate)) || !isValid(new Date(date))) {
-        console.error(
-          `received invalid dates ("${date}", "${endDate}") when trying to find overlapping trips.`,
-        );
-        return [];
-      }
-      return dates().filter((trip) =>
-        areIntervalsOverlapping(
-          { start: date, end: endDate },
-          {
-            start: trip.date,
-            end: trip.endDate,
-          },
-        ),
-      );
-    }
-
-    if (!isValid(new Date(date))) {
-      console.error(
-        `received invalid date "${date}" when trying to find overlapping trips.`,
-      );
-      return [];
-    }
-
-    return dates().filter((trip) =>
-      isWithinInterval(date, {
-        start: trip.date,
-        end: trip.endDate,
-      }),
-    );
-  };
-
   const fallback = <p class="text-gray-500">Add a trip below</p>;
 
   return (
@@ -120,12 +78,8 @@ export const Schengen = () => {
           )}
         </For>
       </ul>
-      <AddSchengenDate
-        dates={dates}
-        overlappingTrips={overlappingTrips}
-        setDates={setDates}
-      />
-      <Summary dates={dates} overlappingTrips={overlappingTrips} />
+      <AddSchengenDate dates={dates} setDates={setDates} />
+      <Summary dates={dates} />
       <Menu dates={dates} resetDates={resetDates} />
     </main>
   );

--- a/app/Schengen/Schengen.tsx
+++ b/app/Schengen/Schengen.tsx
@@ -111,10 +111,9 @@ export const Schengen = () => {
                   />
                 </div>
                 <SchengenTrip
-                  date={date.date}
+                  trip={date}
+                  otherTrips={dates}
                   daysRemainingAt={daysRemainingAt}
-                  endDate={date.endDate}
-                  name={date.name}
                 />
               </div>
             </li>

--- a/app/Schengen/SchengenTrip.tsx
+++ b/app/Schengen/SchengenTrip.tsx
@@ -7,7 +7,7 @@ import {
   isSameDay,
 } from "date-fns";
 import { Strong } from "common/Strong";
-import { Show } from "solid-js";
+import { JSX, Show } from "solid-js";
 import { twClass } from "common/twClass";
 import { SchengenDate } from "app/Schengen/types";
 import { formattedDate } from "common/formattedDate";
@@ -38,63 +38,59 @@ export const SchengenTrip = (props: Props) => {
       </span>
     ) : undefined;
 
+  let relativeDuration: JSX.Element;
+
   const isFuture = isAfter(props.date, now);
+  const isPast = isBefore(endDate, now);
+
   if (isFuture) {
-    return (
-      <p class={className()} data-testid="day">
+    relativeDuration = (
+      <>
         <span>It's </span>
         <span>{diff(now, props.date)}</span>
         <span> until </span>
         <Show when={props.name} fallback={<span>trip</span>}>
           <Strong>{props.name}</Strong>
         </Show>
-        <span>
-          {" "}
-          ({formattedDate(props.date)} - {formattedDate(endDate)},{" "}
-          {formattedDuration()})
-        </span>
-        {error()}
-      </p>
+      </>
     );
-  }
-
-  const isPast = isBefore(endDate, now);
-  if (isPast) {
-    return (
-      <p class={className()} data-testid="day">
+  } else if (isPast) {
+    relativeDuration = (
+      <>
         <span>It's been </span>
         <span>{diff(endDateForDiff(), now)}</span>
         <span> since </span>
         <Show when={props.name} fallback={<span>trip</span>}>
           <Strong>{props.name}</Strong>
         </Show>
-        <span>
-          {" "}
-          ({formattedDate(props.date)} - {formattedDate(endDate)},{" "}
-          {formattedDuration()})
-        </span>
-        {error()}
-      </p>
+      </>
+    );
+  }
+  // else: is present
+  else {
+    relativeDuration = (
+      <>
+        <Show when={!isSameDay(props.date, now)}>
+          <span>It's been </span>
+          <span>{diff(props.date, now)}</span>
+          <span> since </span>
+        </Show>
+        <Show when={props.name} fallback={<span>trip</span>}>
+          <Strong>{props.name}</Strong>
+        </Show>
+        <Show when={isSameDay(props.date, now)}>
+          <span> starts today</span>
+        </Show>
+        <span>, </span>
+        <span>{diff(now, endDateForDiff()!)}</span>
+        <span> remaining</span>
+      </>
     );
   }
 
-  // else: is present
   return (
     <p class={className()} data-testid="day">
-      <Show when={!isSameDay(props.date, now)}>
-        <span>It's been </span>
-        <span>{diff(props.date, now)}</span>
-        <span> since </span>
-      </Show>
-      <Show when={props.name} fallback={<span>trip</span>}>
-        <Strong>{props.name}</Strong>
-      </Show>
-      <Show when={isSameDay(props.date, now)}>
-        <span> starts today</span>
-      </Show>
-      <span>, </span>
-      <span>{diff(now, endDateForDiff()!)}</span>
-      <span> remaining</span>
+      {relativeDuration}
       <span>
         {" "}
         ({formattedDate(props.date)} - {formattedDate(endDate)},{" "}

--- a/app/Schengen/SchengenTrip.tsx
+++ b/app/Schengen/SchengenTrip.tsx
@@ -1,5 +1,6 @@
 import {
   addDays,
+  areIntervalsOverlapping,
   differenceInCalendarDays,
   format,
   isAfter,
@@ -7,50 +8,71 @@ import {
   isSameDay,
 } from "date-fns";
 import { Strong } from "common/Strong";
-import { JSX, Show } from "solid-js";
+import { Accessor, For, JSX, Show } from "solid-js";
 import { twClass } from "common/twClass";
 import { SchengenDate } from "app/Schengen/types";
 import { formattedDate } from "common/formattedDate";
+import { Icon } from "common/Icon";
+import { isEqual } from "lodash";
 
 const diff = (start: Date | string, end: Date | string) =>
   `${differenceInCalendarDays(end, start)} days`;
 
-type Props = SchengenDate & {
+type Props = {
   class?: string;
   daysRemainingAt: (date: Date | string) => number;
+  trip: SchengenDate;
+  otherTrips: Accessor<SchengenDate[]>;
 };
 
 export const SchengenTrip = (props: Props) => {
   const now = format(new Date(), "yyyy-MM-dd");
-  const endDate = isAfter(props.endDate, props.date) ? props.endDate : now;
+  const endDate = isAfter(props.trip.endDate, props.trip.date)
+    ? props.trip.endDate
+    : now;
   const endDateForDiff = () => addDays(endDate, 1);
 
-  const duration = () => differenceInCalendarDays(endDateForDiff(), props.date);
+  const duration = () =>
+    differenceInCalendarDays(endDateForDiff(), props.trip.date);
   const formattedDuration = () => `${duration()} days`;
 
-  const isOverstay = () => duration() > props.daysRemainingAt(props.date);
+  const isOverstay = () => duration() > props.daysRemainingAt(props.trip.date);
   const className = () =>
     isOverstay() ? twClass(props.class, "text-red-500") : props.class;
   const error = () =>
     isOverstay() ? (
       <span class="block text-sm">
-        Cannot stay longer than {props.daysRemainingAt(props.date)} days.
+        Cannot stay longer than {props.daysRemainingAt(props.trip.date)} days.
       </span>
     ) : undefined;
 
+  const overlappingTrips = () =>
+    props
+      .otherTrips()
+      .filter((trip) => !isEqual(trip, props.trip))
+      .filter((trip) =>
+        areIntervalsOverlapping(
+          { start: props.trip.date, end: endDate },
+          {
+            start: trip.date,
+            end: trip.endDate,
+          },
+        ),
+      );
+
   let relativeDuration: JSX.Element;
 
-  const isFuture = isAfter(props.date, now);
+  const isFuture = isAfter(props.trip.date, now);
   const isPast = isBefore(endDate, now);
 
   if (isFuture) {
     relativeDuration = (
       <>
         <span>It's </span>
-        <span>{diff(now, props.date)}</span>
+        <span>{diff(now, props.trip.date)}</span>
         <span> until </span>
-        <Show when={props.name} fallback={<span>trip</span>}>
-          <Strong>{props.name}</Strong>
+        <Show when={props.trip.name} fallback={<span>trip</span>}>
+          <Strong>{props.trip.name}</Strong>
         </Show>
       </>
     );
@@ -60,8 +82,8 @@ export const SchengenTrip = (props: Props) => {
         <span>It's been </span>
         <span>{diff(endDateForDiff(), now)}</span>
         <span> since </span>
-        <Show when={props.name} fallback={<span>trip</span>}>
-          <Strong>{props.name}</Strong>
+        <Show when={props.trip.name} fallback={<span>trip</span>}>
+          <Strong>{props.trip.name}</Strong>
         </Show>
       </>
     );
@@ -70,15 +92,15 @@ export const SchengenTrip = (props: Props) => {
   else {
     relativeDuration = (
       <>
-        <Show when={!isSameDay(props.date, now)}>
+        <Show when={!isSameDay(props.trip.date, now)}>
           <span>It's been </span>
-          <span>{diff(props.date, now)}</span>
+          <span>{diff(props.trip.date, now)}</span>
           <span> since </span>
         </Show>
-        <Show when={props.name} fallback={<span>trip</span>}>
-          <Strong>{props.name}</Strong>
+        <Show when={props.trip.name} fallback={<span>trip</span>}>
+          <Strong>{props.trip.name}</Strong>
         </Show>
-        <Show when={isSameDay(props.date, now)}>
+        <Show when={isSameDay(props.trip.date, now)}>
           <span> starts today</span>
         </Show>
         <span>, </span>
@@ -93,10 +115,26 @@ export const SchengenTrip = (props: Props) => {
       {relativeDuration}
       <span>
         {" "}
-        ({formattedDate(props.date)} - {formattedDate(endDate)},{" "}
+        ({formattedDate(props.trip.date)} - {formattedDate(endDate)},{" "}
         {formattedDuration()})
       </span>
       {error()}
+      <For each={overlappingTrips()}>
+        {(trip) => {
+          const tripDates = `${formattedDate(trip.date)} - ${formattedDate(trip.endDate)}`;
+          return (
+            <p class="flex items-center space-x-1 text-red-500">
+              <Icon name="warning" />
+              <span>overlaps with </span>
+              <span>
+                <Show when={trip.name} fallback={tripDates}>
+                  {trip.name} ({tripDates})
+                </Show>
+              </span>
+            </p>
+          );
+        }}
+      </For>
     </p>
   );
 };

--- a/app/Schengen/Summary.tsx
+++ b/app/Schengen/Summary.tsx
@@ -11,10 +11,6 @@ type Trip = SchengenDate & { duration: number };
 
 type Props = {
   dates: Accessor<SchengenDate[]>;
-  overlappingTrips: (
-    date: Date | string,
-    endDate?: Date | string,
-  ) => SchengenDate[];
 };
 
 export const Summary: Component<Props> = (props) => {
@@ -28,7 +24,7 @@ export const Summary: Component<Props> = (props) => {
       endDate: date.endDate || now,
       duration: 1 + differenceInCalendarDays(date.endDate || now, date.date),
     }));
-  const { daysRemainingAt } = useTrips(trips);
+  const { daysRemainingAt, overlappingTrips } = useTrips(trips);
 
   const availableEnterDates = () => {
     const enterDates: (Trip & {
@@ -37,27 +33,28 @@ export const Summary: Component<Props> = (props) => {
 
     for (let i = 0; i < 365; i++) {
       const potentialEnterDate = addDays(now, i);
-      if (props.overlappingTrips(potentialEnterDate).length) continue;
+      if (overlappingTrips(potentialEnterDate).length) continue;
 
       const remaining = daysRemainingAt(potentialEnterDate);
 
       if (enterDates.at(-1)?.duration === remaining) continue;
 
       const potentialEndDate = addDays(potentialEnterDate, remaining - 1);
-      const overlappingTrips = props
-        .overlappingTrips(potentialEnterDate, potentialEndDate)
-        .map((trip) => ({
-          name: trip.name,
-          dates: [trip.date, trip.endDate]
-            .map((date) => formattedDate(date))
-            .join(" - "),
-        }));
+      const overlapping = overlappingTrips(
+        potentialEnterDate,
+        potentialEndDate,
+      ).map((trip) => ({
+        name: trip.name,
+        dates: [trip.date, trip.endDate]
+          .map((date) => formattedDate(date))
+          .join(" - "),
+      }));
 
       enterDates.push({
         date: format(potentialEnterDate, "yyyy-MM-dd"),
         duration: remaining,
         endDate: format(potentialEndDate, "yyyy-MM-dd"),
-        overlappingTrips,
+        overlappingTrips: overlapping,
       });
     }
 


### PR DESCRIPTION
warns user about overlapping trips.

- mark trips as overlapping when adding new
- simplify rendering logic
- mark overlapping trips on the list
- move overlap logic to hook

fixes DEV-157
